### PR TITLE
Update specs with some ES6 goodness.

### DIFF
--- a/spec/calculator-spec.js
+++ b/spec/calculator-spec.js
@@ -1,18 +1,16 @@
 describe("calculator", function() {
-  var calculator = require('../lib/calculator.js');
-  var moment = require('moment');
+  const calculator = require('../lib/calculator.js');
+  const moment = require('moment');
 
-  it("is a function", function() {
+  it("is a function", () => {
     expect(typeof(calculator)).toEqual("function");
   });
 
-  describe("nothing is outdated", function() {
-    it("prints a total of 0.0", function() {
-      var outdated = '';
-      var releaseTime = function() {
-        throw "test failed: unexpected call"
-      };
-      var stdout = { write: function() {} };
+  describe("nothing is outdated", () => {
+    it("prints a total of 0.0", () => {
+      const outdated = '';
+      const releaseTime = () => { throw "test failed: unexpected call" };
+      const stdout = { write: () => {} };
       spyOn(stdout, 'write');
       calculator(outdated, releaseTime, stdout);
       expect(stdout.write).toHaveBeenCalledWith(
@@ -21,9 +19,9 @@ describe("calculator", function() {
     });
   });
 
-  describe("a package is outdated", function() {
-    it("prints the expected output", function() {
-      var outdated = JSON.stringify(
+  describe("a package is outdated", () => {
+    it("prints the expected output", () => {
+      const outdated = JSON.stringify(
         {
           "banana": {
             "current": "1.0.0",
@@ -33,14 +31,14 @@ describe("calculator", function() {
           }
         }
       );
-      var releaseTime = function(packageName, version) {
+      const releaseTime = (packageName, version) => {
         return {
           "1.0.0": moment("2016-02-28"),
           "1.0.1": moment("2016-02-29"),
           "2.0.0": moment("2017-02-28")
         }[version];
       };
-      var stdout = { write: function() {} };
+      const stdout = { write: () => {} };
       spyOn(stdout, 'write');
       calculator(outdated, releaseTime, stdout);
       expect(stdout.write).toHaveBeenCalledWith(


### PR DESCRIPTION
- Use const instead of var, as const declarations are not "hoisted" so they
  are actually lexically scoped.
- Use arrow funcs for brevity