### PR TITLE
Use a node executable instead of a bash one so that bin symlinks work

### DIFF
--- a/bin/libyear-npm
+++ b/bin/libyear-npm
@@ -1,5 +1,2 @@
-#!/usr/bin/env bash
-set -e
-basedir=`dirname "$0"`
-libyear_npm_js="$basedir/../lib/libyear-npm.js"
-node "$libyear_npm_js"
+#!/usr/bin/env node
+require('../lib/libyear-npm.js');


### PR DESCRIPTION
This resolves a problem running symlinks to bin/libyear-npm. E.g. if the package
was installed globally with `npm install -g`, the symlink at
`/usr/local/bin/libyear-npm` would result in an error like:

> Error: Cannot find module '/usr/local/lib/libyear-npm.js'

`require` seems to "just work" when it comes to resolving symlinks and
module paths, and the node executable is even simpler than the bash one.