### PR TITLE
Fix: make execSync call compatible with node 12.6.0

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -10,11 +10,11 @@ function outdated() {
   try {
     // If there are no outdated pacakges, npm will exit with status 0 and
     // `execSync` will not throw.
-    stdout = execSync(cmd, { timeout: 30000 });
+    stdout = execSync(cmd, { timeout: 30000, encoding: 'utf8' });
   } catch(e) {
     // When npm exits with status code 1, it is normal and indicates that some
     // packages are out of date.
-    if (e.status === 1 && _.isNull(e.error)) {
+    if (e.status === 1 && (_.isNull(e.error) || _.isUndefined(e.error))) {
       stdout = e.stdout;
     } else {
       process.stderr.write('Failed to run: ' + cmd + '\n');


### PR DESCRIPTION
I was getting the following error with node 12.6: 
```
Failed to run: npm outdated --json
Command failed: npm outdated --json
```

Turns out node 12 has default encoding set to:
`encoding <string> The encoding used for all stdio inputs and outputs. Default: 'buffer'.` 
[See node 12 doc](https://nodejs.org/dist/latest-v12.x/docs/api/child_process.html#child_process_child_process_execsync_command_options)

Also, `error` is `undefined` instead of `null` 
